### PR TITLE
Bnyahserial uint64 nanosecond timestamps

### DIFF
--- a/rb_ws/src/buggy/scripts/serial/host_comm.py
+++ b/rb_ws/src/buggy/scripts/serial/host_comm.py
@@ -155,7 +155,7 @@ class SCSensors:
 @dataclass
 class RoundtripTimestamp:
     fw_time: int
-    returned_time: float
+    returned_time: int  # uint64
 
 
 class IncompletePacket(Exception):
@@ -192,8 +192,8 @@ class Comms:
     def send_alarm(self, status: int):
         self.send_packet_raw(MSG_TYPE_ALARM, struct.pack('<B', status))
 
-    def send_timestamp(self, time: float):
-        self.send_packet_raw(MSG_TYPE_SOFTWARE_TIMESTAMP, struct.pack('<f', time))
+    def send_timestamp(self, time: int):
+        self.send_packet_raw(MSG_TYPE_SOFTWARE_TIMESTAMP, struct.pack('<Q', time))
 
     def read_packet_raw(self):
         self.rx_buffer += self.port.read_all() #type:ignore
@@ -288,7 +288,7 @@ class Comms:
             return SCSensors(*data)
 
         elif msg_type == MSG_TYPE_ROUNDTRIP_TIMESTAMP:
-            time = struct.unpack('<If', payload)
+            time = struct.unpack('<IQ', payload)
             return RoundtripTimestamp(*time)
         else:
             print(f'Unknown packet type {msg_type}')

--- a/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
+++ b/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
@@ -186,9 +186,9 @@ class Translator(Node):
 
 
             elif isinstance(packet, RoundtripTimestamp):
-
-                self.get_logger().debug(f'Roundtrip Timestamp: {packet.returned_time}, {(time.time_ns() * 1e-6 - packet.returned_time) * 1e-3}')
-                self.roundtrip_time_publisher.publish(Float64(data=(time.time_ns() - packet.returned_time) * 1e-9))
+                rtt = (time.time_ns() - packet.returned_time) * 1e-9
+                self.get_logger().debug(f'Roundtrip Timestamp: {packet.returned_time}, RTT: {rtt}')
+                self.roundtrip_time_publisher.publish(Float64(data=rtt))
 
         if self.fresh_steer:
             with self.lock:


### PR DESCRIPTION
Updated RTT messages to use uint64 nanosecond timestamps instead of floats

TODO (This must be done before PR is merged)
 - [ ] Ensure RTT time passes basic sniff tests and is displayed properly on foxglove on live buggy