### PR TITLE
Added UKF Covariance for NAND State

### DIFF
--- a/rb_ws/src/buggy/scripts/serial/host_comm.py
+++ b/rb_ws/src/buggy/scripts/serial/host_comm.py
@@ -100,6 +100,10 @@ class NANDUKF:
     easting: float # double
     northing: float # double
     theta: float # double
+    eastern_cov : float
+    northern_cov : float
+    heading_cov : float
+    speed_cov : float
     heading_rate: float # double
     velocity: float # double
     # 32 bits
@@ -270,7 +274,7 @@ class Comms:
             return NANDDebugInfo(*data)
 
         elif msg_type == MSG_TYPE_NAND_UKF:
-            data = struct.unpack('<dddddIxxxx', payload)
+            data = struct.unpack('<dddddddddIxxxx', payload)
             return NANDUKF(*data)
 
         elif msg_type == MSG_TYPE_NAND_GPS:

--- a/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
+++ b/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
@@ -169,6 +169,9 @@ class Translator(Node):
                 odom.pose.pose.position.y = packet.northing
                 odom.pose.pose.orientation.z = packet.theta
 
+                # Updated the easter, northing, and heading (quaternion z) index of variance
+                odom.pose.covariance = np.diag([packet.eastern_cov, packet.northern_cov, 0, 0, 0, packet.heading_cov, 0]).reshape(-1).tolist()
+
                 self.nandCircArray[self.nandIndex] = packet.velocity
                 self.nandIndex = (self.nandIndex + 1) % self.CIRCLEN
                 odom.twist.twist.linear.x = np.mean(self.nandCircArray)

--- a/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
+++ b/rb_ws/src/buggy/scripts/serial/ros_to_bnyahaj.py
@@ -169,8 +169,9 @@ class Translator(Node):
                 odom.pose.pose.position.y = packet.northing
                 odom.pose.pose.orientation.z = packet.theta
 
-                # Updated the easter, northing, and heading (quaternion z) index of variance
-                odom.pose.covariance = np.diag([packet.eastern_cov, packet.northern_cov, 0, 0, 0, packet.heading_cov, 0]).reshape(-1).tolist()
+                # Updated the eastern, northing, and heading (yaw) index of variance
+                # Important note: covariance operates on (x, y, z, pitch, roll, yaw)
+                odom.pose.covariance = np.diag([packet.eastern_cov, packet.northern_cov, 0, 0, 0, packet.heading_cov]).reshape(-1).tolist()
 
                 self.nandCircArray[self.nandIndex] = packet.velocity
                 self.nandIndex = (self.nandIndex + 1) % self.CIRCLEN


### PR DESCRIPTION
- The major update was to add in the names to the host_comm struct
- And then properly populate the covariance matrix. 


To check:
No other upstream fixes are needed, that host comm was fixed (check during mocc rolls), and that I populated covariance properly. 