### PR TITLE
added accuracy check to the initialization code

### DIFF
--- a/rb_ws/src/buggy/scripts/controller/controller_node.py
+++ b/rb_ws/src/buggy/scripts/controller/controller_node.py
@@ -30,7 +30,6 @@ class Controller(Node):
         start_dist = self.get_parameter("dist").value
         # initially set to a high value 
         self.accuracy = 500
-
         self.declare_parameter("stateTopic", "self/state")
         self.declare_parameter("steeringTopic", "input/steering")
         self.declare_parameter("rawSteeringTopic", "input/steering_raw")
@@ -129,8 +128,7 @@ class Controller(Node):
 
         if self.get_namespace() == "/NAND" and self.accuracy > 50:
             self.get_logger().warn("bad accuracy value on nand!")
-            return False 
-        
+            return False
         current_heading = odom.pose.pose.orientation.z % (2 * np.pi)
         closest_heading = (self.cur_traj.get_heading_by_index(self.cur_traj.get_closest_index_on_path(odom.pose.pose.position.x, odom.pose.pose.position.y))) % (2 * np.pi)
 

--- a/rb_ws/src/buggy/scripts/controller/controller_node.py
+++ b/rb_ws/src/buggy/scripts/controller/controller_node.py
@@ -86,7 +86,7 @@ class Controller(Node):
         self.timer = self.create_timer(timer_period, self.loop)
 
     def set_acc(self, msg: NANDRawGPSMsg):
-        self.accuracy = msg.gps_fix
+        self.accuracy = msg.accuracy
 
     def odom_listener(self, msg : Odometry):
         '''

--- a/rb_ws/src/buggy/scripts/controller/controller_node.py
+++ b/rb_ws/src/buggy/scripts/controller/controller_node.py
@@ -7,7 +7,7 @@ from rclpy.node import Node
 
 from std_msgs.msg import Float32, Bool, Float64
 from nav_msgs.msg import Odometry
-from buggy.msg import TrajectoryMsg, StampedFloat64Msg
+from buggy.msg import TrajectoryMsg, StampedFloat64Msg, NANDRawGPSMsg
 
 from util.trajectory import Trajectory
 from controller.stanley_controller import StanleyController
@@ -28,6 +28,8 @@ class Controller(Node):
         # Parameters
         self.declare_parameter("dist", 0.0) # Starting Distance along path
         start_dist = self.get_parameter("dist").value
+        # initially set to a high value 
+        self.accuracy = 50
 
         self.declare_parameter("stateTopic", "self/state")
         self.declare_parameter("steeringTopic", "input/steering")
@@ -73,6 +75,7 @@ class Controller(Node):
         self.odom_subscriber = self.create_subscription(Odometry, self.get_parameter("stateTopic").value, self.odom_listener, 1)
         self.traj_subscriber = self.create_subscription(TrajectoryMsg, self.get_parameter("trajectoryTopic").value, self.traj_listener, 1)
         self.steer_offset_subscriber = self.create_subscription(Float64, self.get_parameter("steerOffsetTopic").value, self.offset_listener, 1)
+        self.accuracy_subscriber = self.create_subscription(NANDRawGPSMsg, "debug/raw_gps", self.set_acc, 1)
 
         self.odom = None
         self.passed_init = False
@@ -80,6 +83,9 @@ class Controller(Node):
 
         timer_period = 0.01  # seconds (100 Hz)
         self.timer = self.create_timer(timer_period, self.loop)
+
+    def set_acc(self, msg: NANDRawGPSMsg):
+        self.accuracy = msg.gps_fix
 
     def odom_listener(self, msg : Odometry):
         '''
@@ -121,6 +127,10 @@ class Controller(Node):
             self.get_logger().warn("checking position estimate certainty | current covariance: " + str(odom.pose.covariance[0] ** 2 + odom.pose.covariance[7] ** 2 ))
             return False
 
+        if self.get_namespace() == "/NAND" and self.accuracy > 17:
+            self.get_logger().warn("bad accuracy value on nand!")
+            return False 
+        
         current_heading = odom.pose.pose.orientation.z % (2 * np.pi)
         closest_heading = (self.cur_traj.get_heading_by_index(self.cur_traj.get_closest_index_on_path(odom.pose.pose.position.x, odom.pose.pose.position.y))) % (2 * np.pi)
 

--- a/rb_ws/src/buggy/scripts/controller/controller_node.py
+++ b/rb_ws/src/buggy/scripts/controller/controller_node.py
@@ -28,7 +28,7 @@ class Controller(Node):
         # Parameters
         self.declare_parameter("dist", 0.0) # Starting Distance along path
         start_dist = self.get_parameter("dist").value
-        # initially set to a high value 
+        # initially set to a high value
         self.accuracy = 500
         self.declare_parameter("stateTopic", "self/state")
         self.declare_parameter("steeringTopic", "input/steering")

--- a/rb_ws/src/buggy/scripts/controller/controller_node.py
+++ b/rb_ws/src/buggy/scripts/controller/controller_node.py
@@ -29,7 +29,7 @@ class Controller(Node):
         self.declare_parameter("dist", 0.0) # Starting Distance along path
         start_dist = self.get_parameter("dist").value
         # initially set to a high value 
-        self.accuracy = 50
+        self.accuracy = 500
 
         self.declare_parameter("stateTopic", "self/state")
         self.declare_parameter("steeringTopic", "input/steering")
@@ -127,7 +127,7 @@ class Controller(Node):
             self.get_logger().warn("checking position estimate certainty | current covariance: " + str(odom.pose.covariance[0] ** 2 + odom.pose.covariance[7] ** 2 ))
             return False
 
-        if self.get_namespace() == "/NAND" and self.accuracy > 17:
+        if self.get_namespace() == "/NAND" and self.accuracy > 50:
             self.get_logger().warn("bad accuracy value on nand!")
             return False 
         

--- a/rb_ws/src/buggy/scripts/controller/controller_node.py
+++ b/rb_ws/src/buggy/scripts/controller/controller_node.py
@@ -74,7 +74,9 @@ class Controller(Node):
         self.odom_subscriber = self.create_subscription(Odometry, self.get_parameter("stateTopic").value, self.odom_listener, 1)
         self.traj_subscriber = self.create_subscription(TrajectoryMsg, self.get_parameter("trajectoryTopic").value, self.traj_listener, 1)
         self.steer_offset_subscriber = self.create_subscription(Float64, self.get_parameter("steerOffsetTopic").value, self.offset_listener, 1)
-        self.accuracy_subscriber = self.create_subscription(NANDRawGPSMsg, "debug/raw_gps", self.set_acc, 1)
+        self.accuracy_subscriber = None
+        if self.get_namespace() == "/NAND":
+            self.accuracy_subscriber = self.create_subscription(NANDRawGPSMsg, "debug/raw_gps", self.set_acc, 1)
 
         self.odom = None
         self.passed_init = False


### PR DESCRIPTION
bug that we realized exists:
when auton starts up before firmware's ukf has initialized, we are getting dummy values of 0 for all fields that they send BESIDES rawgps info. this means that the covariance is 0 (which is really good) so our initialization check passes and we initialize everything with a dumb state. dont do that