### PR TITLE
patch nand_estimator.py to fallback to regular GPS state if UKF covariances explode

### DIFF
--- a/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
@@ -112,9 +112,6 @@ class NANDStateEstimator(Node):
 
         y = [msg.pose.pose.position.x, msg.pose.pose.position.y]
 
-        if not self.ukf_ready:
-            return
-
         self.x_hat, self.Sigma, self.singular_flag = ukf_update(
             self.x_hat, self.Sigma, self.Sigma_init, y, self.R
         )
@@ -125,8 +122,6 @@ class NANDStateEstimator(Node):
 
     def init_ukf(self):
         """Reset the UKF and wait for the next measurement to initialize state."""
-        self.ukf_ready = False
-
         self.start = False
         self.x_hat = None
         self.Sigma_init = np.diag([1e-4, 1e-4, 1e-2, 1e-2])  # initial state covariance
@@ -134,8 +129,6 @@ class NANDStateEstimator(Node):
         self.R = self.accuracy_to_mat(50)
         self.Q = np.diag([1e-4, 1e-4, 1e-2, 2.4e-1])
         self.singular_flag = False
-
-        self.ukf_ready = True
         self.ukf_converged = False
 
 
@@ -146,7 +139,7 @@ class NANDStateEstimator(Node):
         - Runs the predict step using the RK4-discretized dynamics.
         - Publishes filtered NAND state and singularity flag at 100 Hz.
         """
-        if (not self.start) or (not self.ukf_ready):
+        if not self.start:
             return
 
         self.x_hat, self.Sigma, self.singular_flag = ukf_predict(

--- a/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
@@ -174,10 +174,15 @@ class NANDStateEstimator(Node):
             # Twist covariance: 6x6 matrix for [v_x, v_y, v_z, w_x, w_y, w_z]
             twist_cov[0, 0] = Sigma[3, 3]         # linear velocity x variance
 
-            pose_var = np.diag(pose_cov)
+            pose_var = np.array([
+                    pose_cov[0, 0],  # x
+                    pose_cov[1, 1],  # y
+                    pose_cov[5, 5],  # yaw
+                ])
+
             twist_var = twist_cov[0, 0]
 
-            if (pose_var > Constants.NAND_UKF_POSE_DIVERGENCE_THRESHOLD
+            if (np.any(pose_var > Constants.NAND_UKF_POSE_DIVERGENCE_THRESHOLD)
                     or twist_var > Constants.NAND_UKF_TWIST_DIVERGENCE_THRESHOLD):
                 if self.ukf_converged:
                     self.ukf_converged = False
@@ -190,8 +195,8 @@ class NANDStateEstimator(Node):
                     self.init_ukf()
                     return
 
-            elif (pose_var < Constants.NAND_UKF_POSE_CONVERGENCE_THRESHOLD
-                    or twist_var < Constants.NAND_UKF_TWIST_CONVERGENCE_THRESHOLD):
+            elif (np.any(pose_var < Constants.NAND_UKF_POSE_CONVERGENCE_THRESHOLD)
+                    or twist_var < Constants.NAND_UKF_TWIST_CONVERGENCE_THRESHOLD) and not self.ukf_converged:
                 self.get_logger().info("NAND State UKF converged!")
                 self.ukf_converged = True
 

--- a/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
@@ -178,6 +178,7 @@ class NANDStateEstimator(Node):
                     or np.any(twist_cov > Constants.NAND_UKF_MAX_ALLOWABLE_COVARIANCE)):
                 if self.ukf_converged:
                     self.ukf_converged = False
+                    self.get_logger().info("Reinitializing UKF")
                     self.init_ukf()
                     return
             elif not self.ukf_converged:

--- a/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
@@ -125,7 +125,7 @@ class NANDStateEstimator(Node):
         """Reset the UKF and wait for the next measurement to initialize state."""
         self.start = False
         self.x_hat = None
-        self.Sigma_init = np.diag([1e-4, 1e-4, 1e-2, 1e-2])  # initial state covariance
+        self.Sigma_init = np.diag([1e-2, 1e-2, 1e-2, 1e-1])  # initial state covariance
         self.Sigma = self.Sigma_init.copy()  # state covariance
         self.R = self.accuracy_to_mat(50)
         self.Q = np.diag([1e-4, 1e-4, 1e-2, 2.4e-1])
@@ -151,7 +151,7 @@ class NANDStateEstimator(Node):
             self.Q,
             [self.steering],
             0.01,
-            [1.3],
+            [Constants.WHEELBASE_NAND],
         )
 
         nand_ukf_msg = Odometry()
@@ -174,16 +174,18 @@ class NANDStateEstimator(Node):
             # Twist covariance: 6x6 matrix for [v_x, v_y, v_z, w_x, w_y, w_z]
             twist_cov[0, 0] = Sigma[3, 3]         # linear velocity x variance
 
-            if (np.any(pose_cov > Constants.NAND_UKF_MAX_ALLOWABLE_COVARIANCE)
-                    or np.any(twist_cov > Constants.NAND_UKF_MAX_ALLOWABLE_COVARIANCE)):
+            pose_var = np.diag(pose_cov)
+            twist_var = twist_cov[0, 0]
+
+            if (pose_var > Constants.NAND_UKF_POSE_DIVERGENCE_THRESHOLD
+                    or twist_var > Constants.NAND_UKF_TWIST_DIVERGENCE_THRESHOLD):
                 if self.ukf_converged:
                     self.ukf_converged = False
                     self.get_logger().info("Reinitializing UKF")
                     self.init_ukf()
                     return
-            elif not self.ukf_converged:
-                # in this branch, guaranteed that the covariances haven't exploded
-                # set ukf_converged flag to true
+            elif (pose_var < Constants.NAND_UKF_POSE_CONVERGENCE_THRESHOLD
+                    or twist_var < Constants.NAND_UKF_TWIST_CONVERGENCE_THRESHOLD):
                 self.ukf_converged = True
 
             nand_ukf_msg.pose.covariance = pose_cov.flatten().tolist()

--- a/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
@@ -181,11 +181,18 @@ class NANDStateEstimator(Node):
                     or twist_var > Constants.NAND_UKF_TWIST_DIVERGENCE_THRESHOLD):
                 if self.ukf_converged:
                     self.ukf_converged = False
+                    self.get_logger().warn(
+                        f"WARNING: NAND State UKF diverged! "
+                        f"Current Pose Covariance: {pose_cov}, "
+                        f"Current Twist Covariance: {twist_cov}"
+                    )
                     self.get_logger().info("Reinitializing UKF")
                     self.init_ukf()
                     return
+
             elif (pose_var < Constants.NAND_UKF_POSE_CONVERGENCE_THRESHOLD
                     or twist_var < Constants.NAND_UKF_TWIST_CONVERGENCE_THRESHOLD):
+                self.get_logger().info("NAND State UKF converged!")
                 self.ukf_converged = True
 
             nand_ukf_msg.pose.covariance = pose_cov.flatten().tolist()

--- a/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
@@ -88,10 +88,6 @@ class NANDStateEstimator(Node):
         super().__init__("NAND_state_estimator")
         self.get_logger().info('Initialized')
 
-        self.start = False
-        self.ukf_ready = False
-        self.x_hat = None
-        self.singular_flag = False
         self.init_ukf()
 
         self.create_subscription(Odometry, "other/stateNoUKF", self.update_measurement, 1)
@@ -140,6 +136,7 @@ class NANDStateEstimator(Node):
         self.singular_flag = False
 
         self.ukf_ready = True
+        self.ukf_converged = False
 
 
     def loop(self):
@@ -185,8 +182,14 @@ class NANDStateEstimator(Node):
 
             if (np.any(pose_cov > Constants.NAND_UKF_MAX_ALLOWABLE_COVARIANCE)
                     or np.any(twist_cov > Constants.NAND_UKF_MAX_ALLOWABLE_COVARIANCE)):
-                self.init_ukf()
-                return
+                if self.ukf_converged:
+                    self.ukf_converged = False
+                    self.init_ukf()
+                    return
+            elif not self.ukf_converged:
+                # in this branch, guaranteed that the covariances haven't exploded
+                # set ukf_converged flag to true
+                self.ukf_converged = True
 
             nand_ukf_msg.pose.covariance = pose_cov.flatten().tolist()
             nand_ukf_msg.twist.covariance = twist_cov.flatten().tolist()

--- a/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
@@ -105,6 +105,7 @@ class NANDStateEstimator(Node):
     def update_measurement(self, msg):
         """Perform UKF measurement update using pose from other/stateNoUKF."""
         if not self.start:
+            self.get_logger().info("STARTED")
             self.start = True
             self.x_hat = np.array(
                 [msg.pose.pose.position.x, msg.pose.pose.position.y, -np.pi / 2, 0.0]

--- a/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/nand_estimator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import numpy as np
 
+import numpy as np
 import rclpy
 from rclpy.node import Node
 
@@ -89,14 +89,10 @@ class NANDStateEstimator(Node):
         self.get_logger().info('Initialized')
 
         self.start = False
-
+        self.ukf_ready = False
         self.x_hat = None
-        self.Sigma_init = np.diag([1e-4, 1e-4, 1e-2, 1e-2]) # initial state covariance
-        self.Sigma = self.Sigma_init  # state covariance
-        self.R = self.accuracy_to_mat(50)
-        self.Q = np.diag([1e-4, 1e-4, 1e-2, 2.4e-1])
-
         self.singular_flag = False
+        self.init_ukf()
 
         self.create_subscription(Odometry, "other/stateNoUKF", self.update_measurement, 1)
         self.create_subscription(StampedFloat64Msg, "other/steering", self.update_steering, 1)
@@ -114,14 +110,36 @@ class NANDStateEstimator(Node):
         """Perform UKF measurement update using pose from other/stateNoUKF."""
         if not self.start:
             self.start = True
-            self.x_hat = np.array([msg.pose.pose.position.x, msg.pose.pose.position.y, -np.pi/2, 0])
+            self.x_hat = np.array(
+                [msg.pose.pose.position.x, msg.pose.pose.position.y, -np.pi / 2, 0.0]
+            )
 
         y = [msg.pose.pose.position.x, msg.pose.pose.position.y]
-        self.x_hat, self.Sigma, self.singular_flag = ukf_update(self.x_hat, self.Sigma, self.Sigma_init, y, self.R)
+
+        if not self.ukf_ready:
+            return
+
+        self.x_hat, self.Sigma, self.singular_flag = ukf_update(
+            self.x_hat, self.Sigma, self.Sigma_init, y, self.R
+        )
 
         # publish singular flag immediately after measurement update, because prediction also writes to the debug singular flag
         singular_flag_msg = Bool(data=self.singular_flag)
         self.singular_flag_publisher.publish(singular_flag_msg)
+
+    def init_ukf(self):
+        """Reset the UKF and wait for the next measurement to initialize state."""
+        self.ukf_ready = False
+
+        self.start = False
+        self.x_hat = None
+        self.Sigma_init = np.diag([1e-4, 1e-4, 1e-2, 1e-2])  # initial state covariance
+        self.Sigma = self.Sigma_init.copy()  # state covariance
+        self.R = self.accuracy_to_mat(50)
+        self.Q = np.diag([1e-4, 1e-4, 1e-2, 2.4e-1])
+        self.singular_flag = False
+
+        self.ukf_ready = True
 
 
     def loop(self):
@@ -131,9 +149,19 @@ class NANDStateEstimator(Node):
         - Runs the predict step using the RK4-discretized dynamics.
         - Publishes filtered NAND state and singularity flag at 100 Hz.
         """
-        if not self.start:
+        if (not self.start) or (not self.ukf_ready):
             return
-        self.x_hat, self.Sigma, self.singular_flag = ukf_predict(self.rk4_dynamics, self.x_hat, self.Sigma, self.Sigma_init, self.Q, [self.steering], 0.01, [1.3])
+
+        self.x_hat, self.Sigma, self.singular_flag = ukf_predict(
+            self.rk4_dynamics,
+            self.x_hat,
+            self.Sigma,
+            self.Sigma_init,
+            self.Q,
+            [self.steering],
+            0.01,
+            [1.3],
+        )
 
         nand_ukf_msg = Odometry()
         nand_ukf_msg.pose.pose.position.x = self.x_hat[0]
@@ -143,17 +171,24 @@ class NANDStateEstimator(Node):
 
         Sigma = self.Sigma
         if Sigma is not None:
-            # Pose covariance: 6x6 matrix for [x, y, z, roll, pitch, yaw]
             pose_cov = np.zeros((6, 6))
+            twist_cov = np.zeros((6, 6))
+
+            # Pose covariance: 6x6 matrix for [x, y, z, roll, pitch, yaw]
             pose_cov[0:2, 0:2] = Sigma[0:2, 0:2]  # x, y variances & cross-covariances
             pose_cov[5, 5] = Sigma[2, 2]          # heading (yaw) variance
             pose_cov[0:2, 5] = Sigma[0:2, 2]      # cross-covariance x,y and yaw
             pose_cov[5, 0:2] = Sigma[2, 0:2]      # cross-covariance yaw and x,y
-            nand_ukf_msg.pose.covariance = pose_cov.flatten().tolist()
 
             # Twist covariance: 6x6 matrix for [v_x, v_y, v_z, w_x, w_y, w_z]
-            twist_cov = np.zeros((6, 6))
             twist_cov[0, 0] = Sigma[3, 3]         # linear velocity x variance
+
+            if (np.any(pose_cov > Constants.NAND_UKF_MAX_ALLOWABLE_COVARIANCE)
+                    or np.any(twist_cov > Constants.NAND_UKF_MAX_ALLOWABLE_COVARIANCE)):
+                self.init_ukf()
+                return
+
+            nand_ukf_msg.pose.covariance = pose_cov.flatten().tolist()
             nand_ukf_msg.twist.covariance = twist_cov.flatten().tolist()
 
         singular_flag_msg = Bool(data=self.singular_flag)

--- a/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
@@ -248,8 +248,9 @@ class SteerOffsetEstimator(Node):
         offset_variance = self.Sigma[-1, -1]
 
         # Checks the offset variance is reasonable, corresponds to 6 deg std deviation.
-        if offset_variance < Constants.OFFSET_THRESHOLD:
-            if not self.ukf_converged:
+        if not offset_variance < Constants.OFFSET_DIVERGENCE_THRESHOLD:
+            if (not self.ukf_converged and
+                    offset_variance < Constants.OFFSET_CONVERGENCE_THRESHOLD):
                 self.get_logger().info("Steer Offset UKF converged!")
                 self.ukf_converged = True
 

--- a/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
@@ -137,6 +137,8 @@ class SteerOffsetEstimator(Node):
         self.last_time = None
 
         self.ukf_converged = False
+        if hasattr(self, "lowPassFilter"):
+            self.lowPassFilter.reset()
 
     def firmware_debug_callback(self, msg):
         """
@@ -256,7 +258,8 @@ class SteerOffsetEstimator(Node):
             # apply low-pass filter to steering offset
             steer_offset_filtered = self.lowPassFilter.update(steer_offset)
             self.offset_publisher_filtered.publish(Float64(data=steer_offset_filtered))
-        else:
+        elif self.ukf_converged:
+            self.get_logger().info("Reinitializing UKF")
             self.reset_filter()
 
 

--- a/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
@@ -136,6 +136,8 @@ class SteerOffsetEstimator(Node):
         self.debug = None   # not used currently, can be used to pass debug info from utils to publish topics
         self.last_time = None
 
+        self.ukf_converged = False
+
     def firmware_debug_callback(self, msg):
         """
         Handle debug/firmware messages to enable/disable and re-init the estimator.
@@ -213,7 +215,18 @@ class SteerOffsetEstimator(Node):
             return
 
         time_delta = 0.01 if not self.last_time else time.time() - self.last_time
-        self.x_hat, self.Sigma, self.singular_flag = ukf_utils.ukf_predict(self.rk4_dynamics, self.x_hat, self.Sigma, self.Sigma_init, self.Q, [self.steering], time_delta, [self.wheelbase])
+        self.x_hat, self.Sigma, self.singular_flag = (
+            ukf_utils.ukf_predict(
+                self.rk4_dynamics,
+                self.x_hat,
+                self.Sigma,
+                self.Sigma_init,
+                self.Q,
+                [self.steering],
+                time_delta,
+                [self.wheelbase]
+            )
+        )
         self.x_hat[2] = self.wrap_angle(self.x_hat[2], np.pi)     # wrap heading
         self.x_hat[4] = self.wrap_angle(self.x_hat[4], np.pi/2)   # wrap steer offset
         self.last_time = time.time()
@@ -233,6 +246,8 @@ class SteerOffsetEstimator(Node):
 
         # Checks the offset variance is reasonable, corresponds to 6 deg std deviation.
         if offset_variance < Constants.OFFSET_THRESHOLD:
+            if not self.ukf_converged:
+                self.ukf_converged = True
 
             # wrap the steering offset to (-pi/2, pi/2]
             steer_offset = np.rad2deg(self.wrap_angle(self.x_hat[4], np.pi/2))
@@ -241,6 +256,8 @@ class SteerOffsetEstimator(Node):
             # apply low-pass filter to steering offset
             steer_offset_filtered = self.lowPassFilter.update(steer_offset)
             self.offset_publisher_filtered.publish(Float64(data=steer_offset_filtered))
+        else:
+            self.reset_filter()
 
 
 

--- a/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
@@ -248,7 +248,7 @@ class SteerOffsetEstimator(Node):
         offset_variance = self.Sigma[-1, -1]
 
         # Checks the offset variance is reasonable, corresponds to 6 deg std deviation.
-        if not offset_variance < Constants.OFFSET_DIVERGENCE_THRESHOLD:
+        if offset_variance < Constants.OFFSET_DIVERGENCE_THRESHOLD:
             if (not self.ukf_converged and
                     offset_variance < Constants.OFFSET_CONVERGENCE_THRESHOLD):
                 self.get_logger().info("Steer Offset UKF converged!")
@@ -261,7 +261,6 @@ class SteerOffsetEstimator(Node):
             # apply low-pass filter to steering offset
             steer_offset_filtered = self.lowPassFilter.update(steer_offset)
             self.offset_publisher_filtered.publish(Float64(data=steer_offset_filtered))
-
         elif self.ukf_converged:
             self.get_logger().warn(
                 f"WARNING: Steer Offset Estimator UKF diverged! "

--- a/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
@@ -190,7 +190,8 @@ class SteerOffsetEstimator(Node):
                 msg.pose.pose.position.y,
                 msg.pose.pose.orientation.z,
                 msg.twist.twist.linear.x,
-                0])
+                0
+            ])
 
         # measurement vector
         y = [msg.pose.pose.position.x, msg.pose.pose.position.y]
@@ -249,6 +250,7 @@ class SteerOffsetEstimator(Node):
         # Checks the offset variance is reasonable, corresponds to 6 deg std deviation.
         if offset_variance < Constants.OFFSET_THRESHOLD:
             if not self.ukf_converged:
+                self.get_logger().info("Steer Offset UKF converged!")
                 self.ukf_converged = True
 
             # wrap the steering offset to (-pi/2, pi/2]
@@ -258,7 +260,12 @@ class SteerOffsetEstimator(Node):
             # apply low-pass filter to steering offset
             steer_offset_filtered = self.lowPassFilter.update(steer_offset)
             self.offset_publisher_filtered.publish(Float64(data=steer_offset_filtered))
+
         elif self.ukf_converged:
+            self.get_logger().warn(
+                f"WARNING: Steer Offset Esitmator UKF diverged! "
+                f"Current Covariance: {self.Sigma} "
+            )
             self.get_logger().info("Reinitializing UKF")
             self.reset_filter()
 

--- a/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
+++ b/rb_ws/src/buggy/scripts/estimation/steer_offset_estimator.py
@@ -264,7 +264,7 @@ class SteerOffsetEstimator(Node):
 
         elif self.ukf_converged:
             self.get_logger().warn(
-                f"WARNING: Steer Offset Esitmator UKF diverged! "
+                f"WARNING: Steer Offset Estimator UKF diverged! "
                 f"Current Covariance: {self.Sigma} "
             )
             self.get_logger().info("Reinitializing UKF")

--- a/rb_ws/src/buggy/scripts/util/LowPassFilter.py
+++ b/rb_ws/src/buggy/scripts/util/LowPassFilter.py
@@ -18,5 +18,8 @@ class LowPassFilter:
         self.filter_value = self.alpha * new_value + (1 - self.alpha) * self.filter_value
         return self.filter_value
 
+    def reset(self, value: float = 0.0) -> None:
+        self.filter_value = value
+
     def value(self) -> float:
         return self.filter_value

--- a/rb_ws/src/buggy/scripts/util/constants.py
+++ b/rb_ws/src/buggy/scripts/util/constants.py
@@ -15,4 +15,5 @@ class Constants:
     # https://en.wikipedia.org/wiki/Circular_error_probable
     CEP50_to_STD = 1 / math.sqrt(-2 * math.log(0.5)) #0.8493218003
 
-    OFFSET_THRESHOLD = ((1 * 3) * math.pi/180)**2 # Convert 1 deg std dev to 3sigma variance (rad)
+    OFFSET_DIVERGENCE_THRESHOLD = ((1 * 3) * math.pi/180)**2 # Convert 1 deg std dev to 3sigma variance (rad)
+    OFFSET_CONVERGENCE_THRESHOLD = (math.pi/180)**2

--- a/rb_ws/src/buggy/scripts/util/constants.py
+++ b/rb_ws/src/buggy/scripts/util/constants.py
@@ -9,9 +9,9 @@ class Constants:
     WHEELBASE_SC = 1.104
     WHEELBASE_NAND = 1.3
     NAND_UKF_POSE_DIVERGENCE_THRESHOLD = np.array([100, 100, 1]) # Max
-    NAND_UKF_TWIST_DIVERGENCE_THRESHOLD = np.array([100, 100, 1]) # Max
+    NAND_UKF_TWIST_DIVERGENCE_THRESHOLD = 100 # Max
     NAND_UKF_POSE_CONVERGENCE_THRESHOLD = np.array([0.1, 0.1, 0.1])
-    NAND_UKF_TWIST_CONVERGENCE_THRESHOLD = np.array([0.1, 0.1, 0.1])
+    NAND_UKF_TWIST_CONVERGENCE_THRESHOLD = 0.1
     # https://en.wikipedia.org/wiki/Circular_error_probable
     CEP50_to_STD = 1 / math.sqrt(-2 * math.log(0.5)) #0.8493218003
 

--- a/rb_ws/src/buggy/scripts/util/constants.py
+++ b/rb_ws/src/buggy/scripts/util/constants.py
@@ -7,6 +7,7 @@ class Constants:
     UTM_ZONE_LETTER = "T"
     WHEELBASE_SC = 1.104
     WHEELBASE_NAND = 1.3
+    NAND_UKF_MAX_ALLOWABLE_COVARIANCE = 100
 
     # https://en.wikipedia.org/wiki/Circular_error_probable
     CEP50_to_STD = 1 / math.sqrt(-2 * math.log(0.5)) #0.8493218003

--- a/rb_ws/src/buggy/scripts/util/constants.py
+++ b/rb_ws/src/buggy/scripts/util/constants.py
@@ -11,7 +11,7 @@ class Constants:
     NAND_UKF_POSE_DIVERGENCE_THRESHOLD = np.array([100, 100, 1]) # Max
     NAND_UKF_TWIST_DIVERGENCE_THRESHOLD = np.array([100, 100, 1]) # Max
     NAND_UKF_POSE_CONVERGENCE_THRESHOLD = np.array([0.1, 0.1, 0.1])
-    NAND_UKF_TWIST_CONVERGENCE_THRESHOLD = 0.1
+    NAND_UKF_TWIST_CONVERGENCE_THRESHOLD = np.array([0.1, 0.1, 0.1])
     # https://en.wikipedia.org/wiki/Circular_error_probable
     CEP50_to_STD = 1 / math.sqrt(-2 * math.log(0.5)) #0.8493218003
 

--- a/rb_ws/src/buggy/scripts/util/constants.py
+++ b/rb_ws/src/buggy/scripts/util/constants.py
@@ -1,4 +1,5 @@
 import math
+import numpy as np
 
 class Constants:
     UTM_EAST_ZERO = 589702.87
@@ -7,8 +8,10 @@ class Constants:
     UTM_ZONE_LETTER = "T"
     WHEELBASE_SC = 1.104
     WHEELBASE_NAND = 1.3
-    NAND_UKF_MAX_ALLOWABLE_COVARIANCE = 100
-
+    NAND_UKF_POSE_DIVERGENCE_THRESHOLD = np.array([100, 100, 1]) # Max
+    NAND_UKF_TWIST_DIVERGENCE_THRESHOLD = np.array([100, 100, 1]) # Max
+    NAND_UKF_POSE_CONVERGENCE_THRESHOLD = np.array([0.1, 0.1, 0.1])
+    NAND_UKF_TWIST_CONVERGENCE_THRESHOLD = 0.1
     # https://en.wikipedia.org/wiki/Circular_error_probable
     CEP50_to_STD = 1 / math.sqrt(-2 * math.log(0.5)) #0.8493218003
 

--- a/rb_ws/src/buggy/scripts/util/constants.py
+++ b/rb_ws/src/buggy/scripts/util/constants.py
@@ -15,5 +15,5 @@ class Constants:
     # https://en.wikipedia.org/wiki/Circular_error_probable
     CEP50_to_STD = 1 / math.sqrt(-2 * math.log(0.5)) #0.8493218003
 
-    OFFSET_DIVERGENCE_THRESHOLD = ((1 * 3) * math.pi/180)**2 # Convert 1 deg std dev to 3sigma variance (rad)
-    OFFSET_CONVERGENCE_THRESHOLD = (math.pi/180)**2
+    OFFSET_DIVERGENCE_THRESHOLD = ((20 * 3) * math.pi/180)**2 # Convert 20 deg std dev to 3sigma variance (rad)
+    OFFSET_CONVERGENCE_THRESHOLD = ((1 * 3) * math.pi/180)**2 # Convert 1 deg std dev to 3sigma variance (rad)


### PR DESCRIPTION
### Overview
As outlined in the title, patched nand_estimator.py to reinit the NAND UKF if its covariance explodes past a certain point. While it resets, the other methods fall back to using GPS state.

### Linked Issues
#(issue number)

### Tasks
- [ ] Test in sim
- [ ] Test during mock rolls
- [ ] Close #(CURRENT 2PR HERE) and merge main into this branch

### Testing
Test during mock rolls/rolls to see if it works
